### PR TITLE
Add message output of Content-Type; Update assertion of Content-Type

### DIFF
--- a/src/main/scripts/ctl/wcs.xml
+++ b/src/main/scripts/ctl/wcs.xml
@@ -5675,7 +5675,8 @@ offering. Enter the grid resolutions below.</p>
          </xsl:variable>
          <xsl:for-each xmlns:xsl="http://www.w3.org/1999/XSL/Transform" select="$request2">
            <xsl:variable name="content-type" select=".//header[matches(name,'Content-Type','i')]/value" />
-           <xsl:if test="not(contains(substring-before($content-type, ';'),'xml'))">
+           <ctl:message>Content-Type: <xsl:value-of select="$content-type"/></ctl:message>
+           <xsl:if test="not(contains($content-type, 'application/vnd.ogc.se_xml'))">
               <ctl:message>[FAIL] Expected XML entity (ServiceExceptionReport) in response, but Content-Type is '<xsl:value-of select="$content-type"/>'.</ctl:message>
               <ctl:fail/>
             </xsl:if>


### PR DESCRIPTION
Updated assertion of Content-Type.  Bugfix for #10.

Content-Types like `application/vnd.ogc.se_xml;charset=UTF-8` are allowed now. If the Content-Type is `application/vnd.ogc.se_xml`, the result of the assertion is `true` / `valid`.
